### PR TITLE
Adding funding.json for OP Retro Funding 5

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+  "opRetro": {
+    "projectId": "0x88f63d18a020e4aefd6093b5234cc5e11e085698bcc7652b370d38939c39097f"
+  }
+}


### PR DESCRIPTION
It's a file needed in order to verify the repo. Trying to get BuidlGuidl Client to qualify for Retro Funding Round 5 under this category:

![image](https://github.com/user-attachments/assets/1a783bbc-48eb-448c-a1dc-6c763c535416)
