### PR TITLE
Enable ws for geth

### DIFF
--- a/ethereum_client_scripts/geth.js
+++ b/ethereum_client_scripts/geth.js
@@ -71,6 +71,15 @@ const execution = pty.spawn(
     "--metrics",
     "--metrics.addr",
     "127.0.0.1",
+    "--ws",
+    "--ws.api",
+    "eth,net,admin",
+    "--ws.origins",
+    "*",
+    "--ws.addr",
+    "127.0.0.1",
+    "--ws.port",
+    "8546"  
   ],
   {
     name: "xterm-color",


### PR DESCRIPTION
This PR adds webSocket api options for Geth execution client via port 8546